### PR TITLE
use package.json instead of blueprint install for index.js dependencies

### DIFF
--- a/blueprints/ticketfly-css/index.js
+++ b/blueprints/ticketfly-css/index.js
@@ -1,21 +1,8 @@
 /* global module */
-
-const postCSSCompilingPackages = [
-  { name: 'broccoli-funnel', target: '^1.1.0' },
-  { name: 'broccoli-merge-trees',target: '^1.2.1' },
-  { name: 'broccoli-postcss-single', target: '^1.2.0' },
-  { name: 'postcss-cssnext', target: '^2.9.0' },
-  { name: 'postcss-import', target: '^9.0.0' }
-];
-
 module.exports = {
   description: 'install ticketfly-css into an Ember CLI project',
 
-  normalizeEntityName: function() {},
-
-  beforeInstall: function(options) {
-    return this.addPackagesToProject(postCSSCompilingPackages);
-  }
+  normalizeEntityName: function() {}
 
   // locals: function(options) {
   //   // Return custom template variables here.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
     "node": ">=6.x"
   },
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^1.2.1",
+    "broccoli-postcss-single": "^1.2.1",
+    "postcss-cssnext": "^2.9.0",
+    "postcss-import": "^9.1.0",
     "ticketfly-css-box-objects": "^0.1.0",
     "ticketfly-css-box-shadow-garnishes": "^0.0.1",
     "ticketfly-css-box-shadow-variables": "^0.0.2",
@@ -64,9 +69,6 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "broccoli-funnel": "^1.1.0",
-    "broccoli-merge-trees": "^1.2.1",
-    "broccoli-postcss-single": "^1.2.0",
     "chai": "^3.5.0",
     "cssnano": "^3.9.1",
     "cssstats": "^3.0.0",
@@ -96,10 +98,8 @@
     "loader.js": "^4.0.10",
     "mocha": "^3.2.0",
     "postcss-cli": "^2.6.0",
-    "postcss-cssnext": "^2.9.0",
     "postcss-custom-properties": "^5.0.1",
     "postcss-discard-comments": "^2.0.4",
-    "postcss-import": "^9.1.0",
     "postcss-importantly": "^0.0.7",
     "postcss-reporter": "^3.0.0",
     "stylelint": "^7.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,7 +834,7 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-postcss-single@1.2.1:
+broccoli-postcss-single@1.2.1, broccoli-postcss-single@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-postcss-single/-/broccoli-postcss-single-1.2.1.tgz#bd4a56dd526325f6569d06cd5ef0fe3afb0974ed"
   dependencies:
@@ -843,16 +843,6 @@ broccoli-postcss-single@1.2.1:
     mkdirp "0.5.1"
     object-assign "4.1.1"
     postcss "5.2.10"
-
-broccoli-postcss-single@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-postcss-single/-/broccoli-postcss-single-1.2.0.tgz#8b22b2bcaf2d68ed06a00f543577cebc14589f4f"
-  dependencies:
-    broccoli-caching-writer "^3.0.0"
-    include-path-searcher "0.1.0"
-    mkdirp "^0.5.0"
-    object-assign "^4.0.1"
-    postcss "^5.0.4"
 
 broccoli-postcss@3.2.1:
   version "3.2.1"
@@ -1650,21 +1640,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
 
-debug@2.3.3:
+debug@2.3.3, debug@^2.1.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
-  dependencies:
-    ms "0.7.2"
-
-debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
 
@@ -5253,7 +5237,7 @@ postcss-less@^0.14.0:
 
 postcss-media-minmax@^2.1.0:
   version "2.1.2"
-  resolved "http://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz#444c5cf8926ab5e4fd8a2509e9297e751649cdf8"
+  resolved "https://registry.yarnpkg.com/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz#444c5cf8926ab5e4fd8a2509e9297e751649cdf8"
   dependencies:
     postcss "^5.0.4"
 


### PR DESCRIPTION
Because these are needed by the addon itself inside of `index.js`, we'll need to declare them as project `dependencies` instead of using blueprint hooks in order to truly address #25.